### PR TITLE
create index.d.ts to support typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { ReactNode } from 'react';
+
+interface CaptchaSettingArgs {
+    captchaEndpoint: string;
+    captchaEnabled?: boolean;
+}
+
+interface CaptchaProps {
+    captchaStyleName?: string;
+    styleName?: string;
+    ref(captcha: Captcha): void;
+}
+
+interface CaptchaSetting {
+    set(setting: CaptchaSettingArgs): void;
+    get(): CaptchaSettingArgs;
+}
+
+export class Captcha extends React.Component<CaptchaProps> {
+    constructor(props: CaptchaProps);
+
+    componentWillMount(): void;
+
+    componentDidMount(): void;
+
+    getCaptchaStyleName(): string;
+
+    getInstance(): any;
+
+    getCaptchaId(): string;
+
+    getUserEnteredCaptchaCode(): string;
+
+    displayHtml(captchaStyleName: string): void;
+
+    reloadImage(): void;
+
+    validateUnsafe(callback: (isHuman: boolean) => void): void;
+
+    generateCaptchaMarkup(captchaStyleName: string): void;
+
+    loadScriptIncludes(captchaStyleName: string): void;
+
+    render(): ReactNode;
+}
+
+export const captchaSettings: CaptchaSetting;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url": "https://captcha.com/support"
   },
   "devDependencies": {
+    "@types/react": "^16.8.24",
     "react": "^0.13.0",
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.1",


### PR DESCRIPTION
I need to use reactjs-captcha with React Typescript but there is no declaration file
so I create type declaration for "Captcha" and "captchaSettings".

P.S. Currently I cannot find return type of method "getInstance" in Captcha component 
so I assign it return type to "any".